### PR TITLE
feat: upload metrics to gist

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -10,6 +10,8 @@ jobs:
         uses: lowlighter/metrics@latest
         with:
           filename: github-metrics.svg
+          output_action: gist
+          committer_gist: ${{ secrets.METRICS_GIST }}
           token: ${{ secrets.METRICS_TOKEN }}
           base: header
           base_indepth: yes
@@ -19,7 +21,7 @@ jobs:
           plugin_languages_details: lines, bytes-size, percentage
           plugin_languages_sections: most-used, recently-used
           plugin_languages_indepth: yes
-          plugin_languages_limit: 2
+          plugin_languages_limit: 3
           plugin_topics: yes
           plugin_topics_limit: 0
           plugin_topics_mode: icons

--- a/README.md
+++ b/README.md
@@ -10,7 +10,5 @@ A **Staff Engineer** with a passion for building systems that can handle anythin
 I love tackling big challenges and pushing boundaries to bring new ideas to life. If it’s mission-critical, high-traffic, and needs to be rock-solid, I’m in! Let’s build the future, one system at a time. 🌐
 
 
-### Metrics
-<picture>
-  <img src="/github-metrics.svg" alt="Metrics">
-</picture>
+## Stats
+<img src="https://gist.githubusercontent.com/rodrigoluizs/d8b505bb2bf436dd9d949c5723d294b0/raw/f185d541d4eb5c0a64acb2e86e1d703632014a15/github-metrics.svg" alt="Metrics" width="100%">


### PR DESCRIPTION

## Description
Enhanced the GitHub Metrics workflow to upload the generated metrics to a Gist. Updated the README to display the Gist-hosted metrics image instead of a local file.

## Changes
- Updated `.github/workflows/metrics.yml` to use the `output_action: gist` option.
- Added a `committer_gist` secret reference for storing metrics in a Gist.
- Modified the README to reference the Gist-hosted metrics image.

## Motivation and Context
These changes allow metrics to be hosted in a Gist, making them easily shareable and accessible without relying on local files in the repository.

## Checklist
- [ ] I have tested the changes locally.
- [ ] Documentation has been updated if necessary.
- [ ] This PR is ready for review.
