### PR TITLE
fix(metrics): switch languages plugin to most-used section

### DIFF
--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -20,7 +20,7 @@ jobs:
           plugin_languages: yes
           plugin_languages_ignored: html, css, tex, less, dockerfile, makefile, qmake, lex, cmake, shell, gnuplot, vue
           plugin_languages_details: lines, bytes-size, percentage
-          plugin_languages_sections: recently-used
+          plugin_languages_sections: most-used
           plugin_languages_indepth: yes
           plugin_languages_limit: 4
 #          plugin_topics: yes


### PR DESCRIPTION
## Summary
- Switch `plugin_languages_sections` from `recently-used` to `most-used` in the metrics workflow
- The `recently-used` analyzer in `lowlighter/metrics` crashes with `TypeError: Cannot destructure property 'committer' of 'undefined'` when encountering commits with missing committer data
- The `most-used` section uses a different code path that avoids the bug

## Test plan
- [ ] Verify the metrics workflow succeeds on the next scheduled or manual run
- [ ] Confirm the generated `github-metrics.svg` renders correctly in the gist